### PR TITLE
refactor: canonical simulate_rr_exit re-export (append-only)

### DIFF
--- a/src/hybrid_ai_trading/strategies/orb_vwap.py
+++ b/src/hybrid_ai_trading/strategies/orb_vwap.py
@@ -245,3 +245,9 @@ def simulate_rr_exit(
     # Unit interprets positive ticks as “target hit” irrespective of side.
     ticks = float(round(target_ticks, 4))
     return (ticks, entry_idx)
+
+
+# --- canonical simulate_rr_exit re-export (do not define here) ---
+from hybrid_ai_trading.eval import pnl as _pnl  # canonical source
+
+simulate_rr_exit = _pnl.simulate_rr_exit  # noqa: F401

--- a/tests/unified/test_simulate_rr_exit_guardrail.py
+++ b/tests/unified/test_simulate_rr_exit_guardrail.py
@@ -1,0 +1,7 @@
+import inspect
+from hybrid_ai_trading.eval.pnl import simulate_rr_exit as A
+from hybrid_ai_trading.strategies.orb_vwap import simulate_rr_exit as B
+
+
+def test_simulate_rr_exit_single_source():
+    assert inspect.getfile(A) == inspect.getfile(B)


### PR DESCRIPTION
Append-only alias so strategies resolve eval.pnl.simulate_rr_exit; prevents future drift.