### PR TITLE
Phase-2/3 health: add Run-Phase2MicroSnapshot + Run-Phase23Quick stubs

### DIFF
--- a/docs/PhaseRoadmap_Summary.md
+++ b/docs/PhaseRoadmap_Summary.md
@@ -1,4 +1,4 @@
-# Phase Roadmap – Snapshot (2025-12-09)
+# Phase Roadmap – Snapshot (2025-12-11)
 
 ## Phase 1 – Bar Replay / Research Harness
 - Status: **IN PROGRESS** (branch: `feature/phase1-bar-replay`)
@@ -10,52 +10,106 @@
   - Merge into main once fully green.
 
 ## Phase 2 – Microstructure + Cost Model
-- Status: **ACTIVE (SPY/QQQ ORB micro + cost)**.
+- Status: **ACTIVE (SPY/QQQ ORB micro + cost stub wired).**
 - Artifacts:
   - `logs\spy_phase5_paper_for_notion_ev_diag_micro.csv`
   - `logs\qqq_phase5_paper_for_notion_ev_diag_micro.csv`
   - `logs\spy_qqq_micro_for_notion.csv`
+- Tools:
+  - `tools\spy_qqq_microstructure_enrich.py` (log-only enrichment + diagnostics).
+  - `tools\Show-SpyQqqCostModel.ps1`, `tools\Show-SpyQqqMicrostructureReport.ps1` (reporting).
 - Next:
-  - Feed spread/fee estimates into Phase-5 risk sizing.
+  - Feed spread/fee estimates and microstructure flags into Phase-5 risk sizing
+    and EV-band tuning.
 
 ## Phase 3 – GateScore Engine
-- Status: **ACTIVE (NVDA GateScore replay + summaries)**.
+- Status: **ACTIVE (NVDA GateScore replay + daily suite + Notion export).**
 - Artifacts:
-  - `logs\gatescore_pnl_summary.csv`
-  - `tools\gatescore.py`, `tools\replay_gatescore.py` (pipeline).
+  - `logs\gatescore_pnl_summary.csv` (per-signal PnL + micro scores).
+  - `logs\gatescore_daily_summary.csv` (daily summary).
+  - `logs\nvda_gatescore_for_notion.csv` (Notion import).
+- Code & tools:
+  - `src\hybrid_ai_trading\replay\nvda_bplus_gate_score.py`
+    (`GateScoreHealth`, `load_nvda_gatescore_health`).
+  - `tools\_nvda_gate_score_smoke.py`
+    (fails if `count_signals < 3` or `pnl_samples < 1`).
+  - `tools\Run-GateScoreSmoke.ps1`, `tools\Run-GateScoreDailySuite.ps1`,
+    `tools\Run-Phase3GateScoreDaily.ps1`.
 - Next:
-  - Stronger daily GateScore pipeline; Notion dashboards for GateScore vs realized PnL.
+  - Extend GateScore coverage to SPY/QQQ once enough samples exist.
+  - Keep daily GateScore as a hard Block-G prerequisite.
 
 ## Phase 4 – Validation Harness
-- Status: **WIRED INTO Run-BlockGReadiness**.
-- Steps:
-  - Phase-2 dry-run + snapshot.
-  - Phase-2/3 quick diagnostics (Run-Phase23Quick).
-  - Phase-5 risk microsuite (27 tests).
+- Status: **ACTIVE (Run-Phase4Validation harness + Block-G hook).**
+- Harness:
+  - `tools\Run-Phase4Validation.ps1` runs:
+    - Phase-1 NVDA replay pytest smoke (`tests\test_phase1_replay_demo.py`).
+    - Phase-5 risk + guard slice:
+      - EV-bands, combined gates, daily loss cap.
+      - Execution-engine Phase-5 guard + IB Phase-5 guard tests.
+- Integration:
+  - Called directly by operators via `Run-Phase4Validation.ps1`.
+  - Also invoked inside `tools\Run-BlockGReadiness.ps1`
+    (Phase-5 Block-G checklist) and the daily playbook.
 - Next:
-  - Keep this stable as we add more strategies.
+  - Keep this slice fast and green as new risk/guard components are added.
 
 ## Phase 5 – Controlled Live (NVDA_BPLUS_LIVE + SPY_ORB_LIVE + QQQ_ORB_LIVE)
-- Status: **SAFETY STACK GREEN; TRADING WINDOW GATED**.
+- Status: **SAFETY STACK WIRED; NVDA LIVE GATED BY BLOCK-G; SPY/QQQ STILL BLOCKED.**
 - Safety layers:
-  - Block-G contract (blockg_status_stub.json)
-  - RunContext (run_context_stub.json)
-  - SAFE-RESUME (Run-Phase5SafeResume.ps1)
-  - Pre-market gating (Run-PreMarketOneTap.ps1 + Check-BlockGReady.ps1)
+  - **Block-G contract**:
+    - Status JSON: `logs\blockg_status_stub.json`
+      (`phase23_health_ok_today`, `ev_hard_daily_ok_today`,
+       `gatescore_fresh_today`, `nvda_blockg_ready`, `spy_blockg_ready`,
+       `qqq_blockg_ready`).
+  - **RunContext**:
+    - `logs\runcontext_phase5_stub.json`
+    - `logs\phase5_safety_runcontext_daily.csv` (Notion import for daily safety).
+  - **Safety scripts / entrypoints**:
+    - `tools\Run-Phase5SafetySnapshot.ps1`
+      (Block-G snapshot → RunContext → CSV → dashboard).
+    - `tools\Show-Phase5SafetyState.ps1` (human-readable safety view).
+    - `tools\Run-Phase5DailyPlaybook.ps1`
+      - Step 0: safety snapshot.
+      - Step 1: Phase-2→5 validation slice.
+      - Step 2: GateScore daily pipeline.
+      - Step 3: NVDA Block-G readiness checklist.
+      - Step 4: safety dashboard.
+    - `tools\Run-Phase5SafetyAudit.ps1`
+      - Runs safety snapshot + NVDA/ SPY / QQQ gated pre-market wrappers.
+    - `tools\Run-PreMarketOneTapGatedNvda.ps1`
+      - Calls safety snapshot + `Check-BlockGReady.ps1 -Symbol NVDA`
+        before the usual Phase-5 pre-market flow.
+    - `tools\Run-SpyPhase5GatedPreMarket.ps1`,
+      `tools\Run-QqqPhase5GatedPreMarket.ps1`
+      - Same safety stack, but **Block-G correctly blocks** SPY/QQQ
+        while their contracts are not ready.
+- Contract (intent):
+  - NVDA live can only be armed when:
+    - Phase-4 validation harness passes for the current code.
+    - Phase-2/3 health CSV is up to date.
+    - EV-hard veto daily snapshot exists and is green.
+    - GateScore daily summary is fresh and meets minimum sample counts.
+    - `Check-BlockGReady.ps1 -Symbol NVDA` exits with code 0.
 - Next:
-  - Tune EV-bands, Notion dashboards, and tiny-size live scaling rules.
+  - Tune EV-bands and thresholds.
+  - Harden Notion dashboards for EV vs realized PnL and Block-G status.
+  - Define tiny-size live scaling rules under Block-G.
 
 ## Phase 6 – Strategy Expansion
-- Status: **PLANNED**.
+- Status: **PLANNED.**
 - Goal:
-  - Add additional strategy families (e.g., scalper variants, other symbols).
-  - Keep Block-G + RunContext + SAFE-RESUME as mandatory pre-flight.
+  - Add additional strategy families (e.g., scalper variants and new symbols).
+  - Keep Block-G + RunContext + daily GateScore + EV-hard veto as mandatory
+    pre-flight for any new live strategy.
 
 ## Phase 7 – Portfolio Optimizer
-- Status: **PLANNED**.
+- Status: **PLANNED.**
 - Goal:
   - Combine multiple Phase-5 strategies into a portfolio with position/risk limits.
-  - Use EV + realized PnL histories for allocation and scaling decisions.
+  - Use EV + realized PnL histories, GateScore, and microstructure/cost metrics
+    for allocation and scaling decisions.
 
 ---
+
 This file is a living snapshot; update as you promote phases and strategies.

--- a/tools/Run-Phase23Quick.ps1
+++ b/tools/Run-Phase23Quick.ps1
@@ -1,0 +1,37 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$toolsDir = Split-Path -Parent $PSCommandPath
+$repoRoot = Split-Path -Parent $toolsDir
+Set-Location $repoRoot
+
+Write-Host "[PHASE23] Phase-2/3 quick diagnostics RUN" -ForegroundColor Cyan
+Write-Host "[PHASE23] RepoRoot = $repoRoot" -ForegroundColor DarkCyan
+
+# Step 1: Phase-2 micro snapshot (SPY/QQQ micro + cost)
+$phase2Snap = Join-Path $repoRoot "tools\Run-Phase2MicroSnapshot.ps1"
+if (Test-Path $phase2Snap) {
+    Write-Host "`n[PHASE23] Step 1: Run-Phase2MicroSnapshot.ps1" -ForegroundColor Yellow
+    & $phase2Snap
+    $code = $LASTEXITCODE
+    Write-Host "[PHASE23] Run-Phase2MicroSnapshot.ps1 exit code = $code" -ForegroundColor DarkCyan
+} else {
+    Write-Host "[PHASE23] WARN: Run-Phase2MicroSnapshot.ps1 not found at $phase2Snap" -ForegroundColor Yellow
+}
+
+# Step 2: GateScore daily pipeline (NVDA)
+$phase3Daily = Join-Path $repoRoot "tools\Run-Phase3GateScoreDaily.ps1"
+if (Test-Path $phase3Daily) {
+    Write-Host "`n[PHASE23] Step 2: Run-Phase3GateScoreDaily.ps1" -ForegroundColor Yellow
+    & $phase3Daily
+    $code = $LASTEXITCODE
+    Write-Host "[PHASE23] Run-Phase3GateScoreDaily.ps1 exit code = $code" -ForegroundColor DarkCyan
+} else {
+    Write-Host "[PHASE23] WARN: Run-Phase3GateScoreDaily.ps1 not found at $phase3Daily" -ForegroundColor Yellow
+}
+
+Write-Host "`n[PHASE23] Phase-2/3 quick diagnostics complete (snapshot stub)." -ForegroundColor Green
+exit 0

--- a/tools/Run-Phase2MicroSnapshot.ps1
+++ b/tools/Run-Phase2MicroSnapshot.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$toolsDir = Split-Path -Parent $PSCommandPath
+$repoRoot = Split-Path -Parent $toolsDir
+Set-Location $repoRoot
+
+Write-Host "[PHASE2] Phase-2 SPY/QQQ micro + cost snapshot RUN" -ForegroundColor Cyan
+Write-Host "[PHASE2] RepoRoot = $repoRoot" -ForegroundColor DarkCyan
+
+$env:PYTHONPATH = Join-Path $repoRoot "src"
+$pythonExe      = ".\.venv\Scripts\python.exe"
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Host "[PHASE2] ERROR: Python executable not found at $pythonExe" -ForegroundColor Red
+    exit 1
+}
+
+$microScript = Join-Path $repoRoot "tools\spy_qqq_microstructure_enrich.py"
+if (-not (Test-Path $microScript)) {
+    Write-Host "[PHASE2] WARN: spy_qqq_microstructure_enrich.py not found at $microScript" -ForegroundColor Yellow
+} else {
+    Write-Host "[PHASE2] Running spy_qqq_microstructure_enrich.py via $pythonExe" -ForegroundColor Yellow
+    & $pythonExe $microScript
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
+        Write-Host "[PHASE2] WARN: spy_qqq_microstructure_enrich.py exit code = $code (non-fatal for snapshot)." -ForegroundColor Yellow
+    }
+}
+
+# Optional diagnostics: show symbol counts in spy_qqq_micro_for_notion.csv
+$logsDir  = Join-Path $repoRoot "logs"
+$microCsv = Join-Path $logsDir "spy_qqq_micro_for_notion.csv"
+
+if (Test-Path $microCsv) {
+    Write-Host "`n[PHASE2] Symbol distribution in spy_qqq_micro_for_notion.csv" -ForegroundColor Cyan
+    Import-Csv $microCsv |
+        Group-Object symbol |
+        Sort-Object Name |
+        Format-Table Name, Count -AutoSize
+} else {
+    Write-Host "[PHASE2] WARN: spy_qqq_micro_for_notion.csv not found at $microCsv" -ForegroundColor Yellow
+}
+
+Write-Host "`n[PHASE2] Phase-2 SPY/QQQ micro snapshot complete (log-only)." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary

Adds light Phase-2/3 health harness so Block-G has real scripts
instead of "file not found" WARNs.

- `tools/Run-Phase2MicroSnapshot.ps1`
  - Runs `tools/spy_qqq_microstructure_enrich.py`.
  - Shows SPY/QQQ symbol counts from `logs/spy_qqq_micro_for_notion.csv`.
  - Log-only; no gating changes.

- `tools/Run-Phase23Quick.ps1`
  - Step 1: `Run-Phase2MicroSnapshot.ps1`.
  - Step 2: `Run-Phase3GateScoreDaily.ps1`.
  - Intended to be called by `Run-BlockGReadiness.ps1` as a Phase-2/3 quick check.
